### PR TITLE
Doc fix.

### DIFF
--- a/lib/DateTime/Set.pm
+++ b/lib/DateTime/Set.pm
@@ -766,9 +766,9 @@ Creates a new set specified via a "recurrence" callback.
 
 The C<span> parameter is optional. It must be a C<DateTime::Span> object.
 
-The span can also be specified using C<begin> / C<after> and C<before>
-/ C<end> parameters, as in the C<DateTime::Span> constructor.  In this
-case, if there is a C<span> parameter it will be ignored.
+The span can also be specified using C<start> / C<after> and C<end> /
+C<before> parameters, as in the C<DateTime::Span> constructor.  In
+this case, if there is a C<span> parameter it will be ignored.
 
     $months = DateTime::Set->from_recurrence(
         after => $dt_now,


### PR DESCRIPTION
The doc says sets can be configured with `begin`/`end` "as in the DateTime::Span" constructor, but in reality it's `start`/`end` (as the Span doc actually says). Using `begin` will cause an exception when trying to build the underlying span.

Also took the opportunity to reorder start, after, end and before to make a little bit clearer which one goes with which.
