### PR TITLE
use the cloned/intersected set to get boundaries

### DIFF
--- a/lib/DateTime/Set.pm
+++ b/lib/DateTime/Set.pm
@@ -514,17 +514,8 @@ sub as_list {
            $set->min->is_infinite;
 
     my @result;
-    my $next = $self->min;
-    if ( $span ) {
-        my $next1 = $span->min;
-        $next = $next1 if $next1 && $next1 > $next;
-        $next = $self->current( $next );
-    }
-    my $last = $self->max;
-    if ( $span ) {
-        my $last1 = $span->max;
-        $last = $last1 if $last1 && $last1 < $last;
-    }
+    my $next = $set->min;
+    my $last = $set->max;
     do {
         push @result, $next if !$span || $span->contains($next);
         $next = $self->next( $next );


### PR DESCRIPTION
This is a little faster than second-guessing the span. And it solves some issues with the `current` call that I ran into with DateTime::Event::ICal. I'll have a performance improvement for that module soon too.